### PR TITLE
feat(xmla): rowset GUIDs with their provenance, and what a client nee…

### DIFF
--- a/api/src/main/java/org/eclipse/daanse/xmla/api/XmlaConnector.java
+++ b/api/src/main/java/org/eclipse/daanse/xmla/api/XmlaConnector.java
@@ -54,6 +54,23 @@ public interface XmlaConnector {
     List<EObject> discover(Discover request, XmlaRequest context);
 
     /**
+     * The request types this connector answers, or an empty set for a connector
+     * that does not say.
+     * <p>
+     * One caller needs it, in one case: a connector that leaves
+     * {@code DISCOVER_SCHEMA_ROWSETS} to the transport leaves the transport to
+     * decide what to announce. Naming the whole model would offer rowsets nobody
+     * can answer, and a client that takes the offer up gets a fault where it was
+     * promised an answer. An empty set means the whole model, and a connector that
+     * answers the rowset itself need not implement this at all.
+     *
+     * @return request types as they appear on the wire, e.g. {@code MDSCHEMA_CUBES}
+     */
+    default java.util.Set<String> served() {
+        return java.util.Set.of();
+    }
+
+    /**
      * The result of one Execute, or {@code null} for a command that produces none.
      * <p>
      * An MDX {@code Statement} answers with a {@code Mddataset} or a

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/EcoreXmlWriter.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/EcoreXmlWriter.java
@@ -13,10 +13,6 @@
  */
 package org.eclipse.daanse.xmla.model.io;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -45,16 +41,12 @@ import org.eclipse.emf.ecore.util.ExtendedMetaData;
 public final class EcoreXmlWriter {
 
     /**
-     * XMLA writes timestamps without a zone offset and with whatever sub-second
-     * precision the value carries, as in {@code 2024-05-13T12:24:33.956667}.
-     * <p>
-     * Both halves are stated explicitly: {@code LocalDateTime.toString()} omits
-     * seconds that are zero, which some clients reject, and a fixed
-     * {@code HH:mm:ss} pattern truncates the fraction.
+     * The XSD types a client reads as text, and the only ones an empty element may
+     * stand in. {@code uuid} is deliberately absent although it is a string
+     * restriction: an empty one is still not a GUID.
      */
-    private static final DateTimeFormatter XMLA_DATE_TIME = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-            .appendFraction(java.time.temporal.ChronoField.NANO_OF_SECOND, 0, 9, true).toFormatter();
+    private static final java.util.Set<String> TEXT_XSD_TYPES = java.util.Set.of("xsd:string", "xsd:anyType",
+            "xsd:anyURI");
 
     private final String namespace;
 
@@ -195,6 +187,13 @@ public final class EcoreXmlWriter {
         }
         String text = asString(feature, value);
         if (text == null || text.isEmpty()) {
+            if (!isTextColumn(feature)) {
+                // An empty element is not an empty value to a client that has been told the
+                // column is a number, a date or a uuid: it parses "" against that type, and
+                // ADOMD stores the resulting FormatException as the cell's value instead of
+                // throwing. Leaving the element out is what says NULL.
+                return;
+            }
             // <DESCRIPTION/>, not <DESCRIPTION></DESCRIPTION>. The two are the same XML
             // to a parser, but SSAS writes the short one and responses are compared byte
             // for byte.
@@ -213,18 +212,27 @@ public final class EcoreXmlWriter {
     }
 
     /**
-     * The element name a contained object takes.
+     * Whether an empty value may travel as an empty element - only where the client
+     * reads the column as text.
      * <p>
-     * Two cases where the feature's own name is not it:
-     * <ul>
-     * <li>the feature's type is abstract, so the concrete subtype decides - an Axis
-     * holds a SetType, and what goes on the wire is {@code <Members>},
-     * {@code <Tuples>}, {@code <CrossProduct>} or {@code <Union>};</li>
-     * <li>the model says {@code elementNameFrom}, meaning the name is a value the
-     * object carries rather than anything the schema fixes - a CellInfoItem is
-     * {@code <FORMATTED_VALUE>} because that is the property the client asked
-     * for.</li>
-     * </ul>
+     * For a number, a date or a {@code uuid} an empty element is not an empty value
+     * but unparseable input: a client keeps the parse failure as the cell's value
+     * rather than throwing, so the row arrives looking valid and holding an error.
+     * Absence is what both sides read as NULL. An untyped column stays, being read
+     * as text anyway.
+     */
+    private static boolean isTextColumn(EStructuralFeature feature) {
+        String type = RowsetSchemaWriter.xsdTypeOrNull(feature);
+        return type == null || TEXT_XSD_TYPES.contains(type);
+    }
+
+    /**
+     * The element name a contained object takes, which is the feature's own name
+     * except in two cases: the feature's type is abstract and the concrete subtype
+     * decides (an Axis holds a SetType, and {@code <Members>}, {@code <Tuples>},
+     * {@code <CrossProduct>} or {@code <Union>} goes on the wire), or the model
+     * says {@code elementNameFrom} and the name is a value the object carries (a
+     * CellInfoItem is {@code <FORMATTED_VALUE>}).
      */
     private static String elementNameOf(EStructuralFeature feature, EObject value, String declared) {
         EAnnotation daanse = value.eClass().getEAnnotation(DAANSE_XMLA);
@@ -294,16 +302,10 @@ public final class EcoreXmlWriter {
 
     /** Converts a value to its lexical form, preferring EMF's own conversion. */
     private static String asString(EStructuralFeature feature, Object value) {
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof LocalDateTime timestamp) {
-            return timestamp.format(XMLA_DATE_TIME);
-        }
         EClassifier type = feature.getEType();
         if (feature instanceof EAttribute && type instanceof EDataType dataType) {
-            return dataType.getEPackage().getEFactoryInstance().convertToString(dataType, value);
+            return Lexical.of(dataType, value);
         }
-        return String.valueOf(value);
+        return Lexical.of(value);
     }
 }

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/Lexical.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/Lexical.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.model.io;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+/**
+ * The lexical form a value takes on the wire.
+ * <p>
+ * Three paths lead there - the element writer, the cell list a DMV projects and
+ * a JDBC result set - and they must agree, because a malformed
+ * {@code xsd:dateTime} is not reported: a client stores the parse failure as the
+ * cell's value and fails much later on a cast.
+ * <p>
+ * Two traps sit in the same spot. {@code LocalDateTime.toString()}
+ * <em>omits seconds that are zero</em>, so midnight becomes
+ * {@code 2026-08-15T00:00}, and the lexical form requires {@code hh:mm:ss};
+ * {@code java.sql.Timestamp.toString()} separates date and time with a space
+ * rather than {@code T}. EMF does not help: the generated
+ * {@code convertDateTimeToString} hands the value to {@code XMLTypeFactory},
+ * which expects a calendar and falls back to {@code toString()}.
+ */
+public final class Lexical {
+
+    /**
+     * XMLA writes timestamps without a zone offset and with whatever sub-second
+     * precision the value carries, as in {@code 2024-05-13T12:24:33.956667}: the
+     * fixed part always writes seconds, the fraction is optional.
+     */
+    private static final DateTimeFormatter XMLA_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss").appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).toFormatter();
+
+    private Lexical() {
+        // static access only
+    }
+
+    /** The lexical form of a timestamp, seconds always written. */
+    public static String of(LocalDateTime timestamp) {
+        return timestamp.format(XMLA_DATE_TIME);
+    }
+
+    /**
+     * The lexical form of a modelled value, preferring EMF's own conversion for
+     * everything it handles correctly.
+     *
+     * @param dataType the datatype the model gives the value, never null
+     * @param value    the value, may be null
+     * @return the lexical form, or null when the value is null
+     */
+    public static String of(EDataType dataType, Object value) {
+        if (value == null) {
+            return null;
+        }
+        String timestamp = timestampOrNull(value);
+        return timestamp != null ? timestamp : EcoreUtil.convertToString(dataType, value);
+    }
+
+    /**
+     * The lexical form of a value whose model type is not known - a JDBC result set
+     * column, say, where the driver decides what Java type arrives.
+     */
+    public static String of(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String timestamp = timestampOrNull(value);
+        return timestamp != null ? timestamp : value.toString();
+    }
+
+    /**
+     * The lexical form of the timestamp kinds a driver or a model may hand us, or
+     * null when the value is not a point in time at all.
+     */
+    private static String timestampOrNull(Object value) {
+        if (value instanceof LocalDateTime timestamp) {
+            return of(timestamp);
+        }
+        if (value instanceof java.sql.Timestamp timestamp) {
+            return of(timestamp.toLocalDateTime());
+        }
+        if (value instanceof java.time.OffsetDateTime timestamp) {
+            // XMLA carries no offset, and the column list a client converts to local time
+            // is written in UTC, so that is what an offset is normalised to.
+            return of(timestamp.atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+        }
+        if (value instanceof java.time.Instant instant) {
+            return of(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
+        }
+        return null;
+    }
+}

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetCatalog.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetCatalog.java
@@ -223,11 +223,10 @@ public final class RowsetCatalog {
      * <p>
      * The order is not presentation: {@code RestrictionsMask} in
      * {@code DISCOVER_SCHEMA_ROWSETS} is a bitmask over exactly these positions.
-     * The list is the feature order of the rowset's restrictions EClass; the wire
-     * name is each feature's {@code ExtendedMetaData} name and the XSD type follows
-     * from its datatype. It is the order the live servers state in the rowset that
-     * carries the mask, not the specification's prose table; the two differ for ten
-     * rowsets including MDSCHEMA_CUBES and MDSCHEMA_MEMBERS.
+     * The list follows the feature order of the rowset's restrictions EClass, which
+     * is the order a live server states in the rowset carrying the mask rather than
+     * the specification's prose table - the two differ for ten rowsets, among them
+     * MDSCHEMA_CUBES and MDSCHEMA_MEMBERS.
      */
     public static List<Restriction> restrictionsOf(EClass eClass) {
         rowsets();
@@ -298,6 +297,8 @@ public final class RowsetCatalog {
             guidOf(entry.getValue()).filter(guid -> !guid.isEmpty())
                     .ifPresent(guid -> described.eSet(row.getEStructuralFeature("schemaGuid"), guid));
             described.eSet(row.getEStructuralFeature("restrictionsMask"), restrictionsMaskOf(entry.getValue()));
+            provenanceOf(entry.getValue())
+                    .ifPresent(text -> described.eSet(row.getEStructuralFeature("description"), text));
 
             // And the type of one restriction is what the feature holding them says
             // it is, which is the model stating it once instead of twice.
@@ -314,6 +315,32 @@ public final class RowsetCatalog {
             rows.add(described);
         }
         return rows;
+    }
+
+    /**
+     * Where a rowset comes from, as the {@code Description} column states it.
+     * <p>
+     * Most of what this server offers is not named by [MS-SSAS]: of the 34
+     * relational rowsets only four are, the rest being OLE DB's own, carried over
+     * so a consumer speaking OLE DB finds them under the name and GUID it knows.
+     * {@code Description} is where that difference belongs - not the name, which is
+     * what a client searches by.
+     *
+     * @return the text, or empty when the model records no source
+     */
+    private static Optional<String> provenanceOf(EClass rowset) {
+        String source = detail(rowset, "source");
+        if (source == null || source.isEmpty()) {
+            return Optional.empty();
+        }
+        String url = detail(rowset, "specUrl");
+        String text = switch (source) {
+        case "OLEDB-APPENDIX-B" -> "OLE DB schema rowset (Appendix B), offered beyond what [MS-SSAS] names";
+        case "PROPRIETARY" -> "Provider-specific rowset, named by neither [MS-SSAS] nor OLE DB";
+        case "INFERRED" -> "Inferred from a related rowset; not separately documented";
+        default -> "[MS-SSAS] " + source;
+        };
+        return Optional.of(url == null || url.isEmpty() ? text : text + " — " + url);
     }
 
     /**

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetResults.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetResults.java
@@ -165,8 +165,7 @@ public final class RowsetResults {
         for (EStructuralFeature feature : row.eClass().getEAllStructuralFeatures()) {
             if (columnName.equals(RowsetSchemaWriter.wireNameOf(feature)) && row.eIsSet(feature) && !feature.isMany()
                     && feature.getEType() instanceof EDataType dataType) {
-                Object value = row.eGet(feature);
-                return value == null ? null : EcoreUtil.convertToString(dataType, value);
+                return Lexical.of(dataType, row.eGet(feature));
             }
         }
         return null;
@@ -202,9 +201,9 @@ public final class RowsetResults {
             }
         } else if (value != null) {
             if (feature.getEType() instanceof EDataType dataType) {
-                cell.setValue(EcoreUtil.convertToString(dataType, value));
+                cell.setValue(Lexical.of(dataType, value));
             } else {
-                cell.setValue(String.valueOf(value));
+                cell.setValue(Lexical.of(value));
             }
         }
         return cell;
@@ -253,7 +252,7 @@ public final class RowsetResults {
                 if (value == null) {
                     continue;
                 }
-                String text = value.toString();
+                String text = Lexical.of(value);
                 if (value instanceof Number) {
                     text = ElementNames.normalizeNumericString(text);
                 }

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetSchemaWriter.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/RowsetSchemaWriter.java
@@ -72,20 +72,40 @@ public final class RowsetSchemaWriter {
      *                               text
      */
     public static String xsdTypeOf(EStructuralFeature feature) {
+        if (feature instanceof EReference) {
+            return null; // a nested rowset: the schema inlines its complexType instead
+        }
+        String resolved = resolveXsdType(feature);
+        if (resolved != null) {
+            return resolved;
+        }
+        throw new IllegalStateException("no XSD type for feature " + feature.getEContainingClass().getName() + "."
+                + feature.getName() + " of type " + feature.getEType().getName()
+                + "; add an xsdType detail or map the datatype");
+    }
+
+    /**
+     * The XSD type for one column, or {@code null} when the model does not
+     * determine it.
+     * <p>
+     * The asking form of {@link #xsdTypeOf}, for the one caller that has a sensible
+     * answer for "unknown" and must not fail the whole response over it.
+     */
+    static String xsdTypeOrNull(EStructuralFeature feature) {
+        return feature instanceof EReference ? null : resolveXsdType(feature);
+    }
+
+    private static String resolveXsdType(EStructuralFeature feature) {
         String override = detail(feature.getEAnnotation(RowsetCatalog.ANNOTATION), "xsdType");
         if (override != null) {
             return override;
-        }
-        if (feature instanceof EReference) {
-            return null; // a nested rowset: the schema inlines its complexType instead
         }
         EClassifier type = feature.getEType();
         if (type instanceof EEnum) {
             String enumType = detail(type.getEAnnotation(RowsetCatalog.ANNOTATION), "xsdType");
             return enumType != null ? enumType : "xsd:string";
         }
-        String name = type.getName();
-        String mapped = XMLTYPE_TO_XSD.get(name);
+        String mapped = XMLTYPE_TO_XSD.get(type.getName());
         if (mapped != null) {
             return mapped;
         }
@@ -93,11 +113,7 @@ public final class RowsetSchemaWriter {
         // type, and it lives in the rowset namespace rather than the XSD one, so it
         // has no prefix.
         String local = ExtendedMetaData.INSTANCE.getName(type);
-        if (local != null && !local.isEmpty()) {
-            return local;
-        }
-        throw new IllegalStateException("no XSD type for feature " + feature.getEContainingClass().getName() + "."
-                + feature.getName() + " of type " + name + "; add an xsdType detail or map the datatype");
+        return local != null && !local.isEmpty() ? local : null;
     }
 
     /** The element name this feature takes on the wire. */

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/SoapEnvelopeWriter.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/SoapEnvelopeWriter.java
@@ -50,13 +50,20 @@ public final class SoapEnvelopeWriter {
         out.writeStartElement(XmlaNamespaces.SOAP_ENV, "Envelope");
         out.writeNamespace(XmlaNamespaces.SOAP_ENV_PREFIX, XmlaNamespaces.SOAP_ENV);
 
-        out.writeStartElement(XmlaNamespaces.SOAP_ENV, "Header");
-        for (EObject header : headers) {
-            // Not every header is in the XMLA namespace: ProtocolCapabilities belongs
-            // to the engine namespace, and a client looks for it there.
-            new EcoreXmlWriter(namespaceOf(header)).write(out, header, wireNameOf(header));
+        // No headers, no Header element, which is what Analysis Services writes. An
+        // empty <soap:Header/> is one self-closing node: a reader that pairs
+        // ReadStartElement with ReadEndElement consumes it on the first call and takes
+        // the next end element with the second, and is one element out of step for the
+        // rest of the document.
+        if (!headers.isEmpty()) {
+            out.writeStartElement(XmlaNamespaces.SOAP_ENV, "Header");
+            for (EObject header : headers) {
+                // Not every header is in the XMLA namespace: ProtocolCapabilities belongs
+                // to the engine namespace, and a client looks for it there.
+                new EcoreXmlWriter(namespaceOf(header)).write(out, header, wireNameOf(header));
+            }
+            out.writeEndElement();
         }
-        out.writeEndElement();
 
         out.writeStartElement(XmlaNamespaces.SOAP_ENV, "Body");
         body.write(out);

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/SoapFaultWriter.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/SoapFaultWriter.java
@@ -75,18 +75,24 @@ public final class SoapFaultWriter {
             writeUnqualified(body, "faultcode", XmlaNamespaces.SOAP_ENV_PREFIX + ":" + kind.code);
             writeUnqualified(body, "faultstring", faultString);
 
-            body.writeStartElement("detail");
-            body.setPrefix(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
-            body.writeStartElement(XmlaNamespaces.EXCEPTION, "Error");
-            body.writeNamespace(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
+            // Only with a code. A client reads the ErrorCode attribute unconditionally -
+            // ADOMD runs XmlConvert.ToUInt32 straight on it and throws on null, so an
+            // <Error> without one replaces our message with the client's own parse
+            // failure. A fault needs either this element or a faultstring, and the
+            // faultstring above is always written, so leaving it out is the honest
+            // option: better no Error element than one carrying an invented code.
             if (errorCode != null) {
+                body.writeStartElement("detail");
+                body.setPrefix(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
+                body.writeStartElement(XmlaNamespaces.EXCEPTION, "Error");
+                body.writeNamespace(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
                 body.writeAttribute("ErrorCode", Long.toUnsignedString(errorCode));
+                body.writeAttribute("Description", description == null ? faultString : description);
+                body.writeAttribute("Source", source == null ? "" : source);
+                body.writeAttribute("HelpFile", "");
+                body.writeEndElement();
+                body.writeEndElement();
             }
-            body.writeAttribute("Description", description == null ? faultString : description);
-            body.writeAttribute("Source", source == null ? "" : source);
-            body.writeAttribute("HelpFile", "");
-            body.writeEndElement();
-            body.writeEndElement();
 
             body.writeEndElement();
         });

--- a/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/XmlaMessageCodec.java
+++ b/model/io/src/main/java/org/eclipse/daanse/xmla/model/io/XmlaMessageCodec.java
@@ -153,12 +153,10 @@ public final class XmlaMessageCodec {
     }
 
     /**
-     * As above, and reporting an error inside a successful response.
-     * <p>
-     * The second of XMLA's two ways to say something went wrong: HTTP 200, a
-     * well-formed {@code <root>} with the inline schema in it, then an empty
-     * {@code <Exception/>} followed by {@code <Messages>}. Unlike a fault it is not
-     * an either/or - a response may carry rows and a message together.
+     * As above, and reporting an error inside a successful response: HTTP 200, a
+     * well-formed {@code <root>} with its inline schema, then an empty
+     * {@code <Exception/>} and {@code <Messages>}. Unlike a fault this is not an
+     * either/or - rows and a message travel together.
      *
      * @param messages a {@code Messages} EObject, or {@code null} when nothing went
      *                 wrong
@@ -179,6 +177,12 @@ public final class XmlaMessageCodec {
             body.writeStartElement(XmlaNamespaces.ROWSET, "root");
             body.writeDefaultNamespace(XmlaNamespaces.ROWSET);
             body.writeNamespace(XmlaNamespaces.XSI_PREFIX, XmlaNamespaces.XSI);
+            // DISCOVER_SCHEMA_ROWSETS writes type names as element content -
+            // <Type>xsd:string</Type> - and it writes them after the inline schema, whose
+            // own xsd binding has gone out of scope by then. A client that resolves the
+            // prefix for real finds nothing and stops. Binding it here costs one
+            // attribute; SSAS binds it on this element too.
+            body.writeNamespace(XmlaNamespaces.XSD_PREFIX, XmlaNamespaces.XSD);
             body.writeNamespace(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
 
             RowsetSchemaWriter.write(body, rowEClass);
@@ -197,12 +201,9 @@ public final class XmlaMessageCodec {
     }
 
     /**
-     * The in-band {@code <Messages>}, and the {@code <Exception/>} that may precede
-     * it.
-     * <p>
-     * The marker is not unconditional: {@code <Exception/>} says something failed,
-     * so it accompanies an {@code <Error>} but not a response carrying only a
-     * {@code <Warning>}.
+     * The in-band {@code <Messages>}, preceded by {@code <Exception/>} only where
+     * something failed: an {@code <Error>} gets the marker, a lone
+     * {@code <Warning>} does not.
      */
     private static void writeMessages(XMLStreamWriter out, EObject messages) throws XMLStreamException {
         if (messages == null) {
@@ -263,6 +264,10 @@ public final class XmlaMessageCodec {
                 body.writeStartElement(XmlaNamespaces.MDDATASET, "root");
                 body.writeDefaultNamespace(XmlaNamespaces.MDDATASET);
                 body.writeNamespace(XmlaNamespaces.XSI_PREFIX, XmlaNamespaces.XSI);
+                // OlapInfo names each column's type as xsd:string, xsd:int and so on, so the
+                // prefix has to be bound here. Without it the attribute values point at
+                // nothing and a client cannot read the axis - MSOLAP says so and stops.
+                body.writeNamespace(XmlaNamespaces.XSD_PREFIX, XmlaNamespaces.XSD);
                 new EcoreXmlWriter(XmlaNamespaces.MDDATASET).writeContent(body, result);
                 writeMessages(body, messages);
                 body.writeEndElement();
@@ -297,6 +302,11 @@ public final class XmlaMessageCodec {
         out.writeStartElement(XmlaNamespaces.ROWSET, "root");
         out.writeDefaultNamespace(XmlaNamespaces.ROWSET);
         out.writeNamespace(XmlaNamespaces.XSI_PREFIX, XmlaNamespaces.XSI);
+        // Bound for the same reason as on the Discover root, and because a variant cell
+        // names its own type as xsi:type="xsd:int" - a QName whose prefix must resolve.
+        out.writeNamespace(XmlaNamespaces.XSD_PREFIX, XmlaNamespaces.XSD);
+        // writeMessages below may emit EX:Exception and EX:Messages into this root.
+        out.writeNamespace(XmlaNamespaces.EXCEPTION_PREFIX, XmlaNamespaces.EXCEPTION);
 
         if (rowset.isSchemaIncluded()) {
             List<RowsetSchemaWriter.Column> columns = new java.util.ArrayList<>();
@@ -350,6 +360,8 @@ public final class XmlaMessageCodec {
                 out.writeStartElement(XmlaNamespaces.MDDATASET, "root");
                 out.writeDefaultNamespace(XmlaNamespaces.MDDATASET);
                 out.writeNamespace(XmlaNamespaces.XSI_PREFIX, XmlaNamespaces.XSI);
+                // As above: the axis types are written as xsd:-qualified names.
+                out.writeNamespace(XmlaNamespaces.XSD_PREFIX, XmlaNamespaces.XSD);
                 new EcoreXmlWriter(XmlaNamespaces.MDDATASET).writeContent(out, entry);
                 out.writeEndElement();
             }

--- a/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/GuidCatalogTest.java
+++ b/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/GuidCatalogTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.model.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.eclipse.emf.ecore.EAnnotation;
+import org.eclipse.emf.ecore.EClass;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The GUIDs a client resolves a rowset by, and why every one of them has to be
+ * right.
+ * <p>
+ * A client knows a rowset by name or by GUID. ADOMD.NET hard-wires
+ * twenty-eight; for every other rowset it fills its lookup table from the
+ * {@code SchemaGuid} column of our own {@code DISCOVER_SCHEMA_ROWSETS}, and only
+ * where that column is present and not empty. Where it is missing,
+ * {@code GetSchemaDataSet(Guid)} throws before a request ever reaches us. So a
+ * missing GUID is not a blemish: it is a rowset unreachable by half the API.
+ * <p>
+ * A <em>wrong</em> GUID is worse than a missing one — it points the client at
+ * some other rowset, and nothing in a running server reveals it. Hence this
+ * test, and hence the {@code guidSource} detail every value carries.
+ */
+class GuidCatalogTest {
+
+    /** Canonical 8-4-4-4-12. Case is free: the client parses case-insensitively. */
+    private static final Pattern SHAPE = Pattern
+            .compile("[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}");
+
+    /**
+     * The one duplicate that is not ours to fix.
+     * <p>
+     * A real Analysis Services advertises the same GUID on both of these rows, and
+     * ADOMD.NET declares it twice under two field names. Dropping it from one would
+     * not make the other reachable — it would only make both unreachable by GUID.
+     */
+    private static final Set<String> SHARE_ONE_GUID = Set.of("DMSCHEMA_MINING_MODEL_XML",
+            "DMSCHEMA_MINING_MODEL_CONTENT_PMML");
+
+    private static Optional<String> detail(EClass eClass, String key) {
+        EAnnotation annotation = eClass.getEAnnotation(RowsetCatalog.ANNOTATION);
+        return annotation == null ? Optional.empty() : Optional.ofNullable(annotation.getDetails().get(key));
+    }
+
+    private static Map<String, EClass> rowsets() {
+        Map<String, EClass> all = new LinkedHashMap<>();
+        for (String requestType : RowsetCatalog.requestTypes()) {
+            RowsetCatalog.forRequestType(requestType).ifPresent(eClass -> all.put(requestType, eClass));
+        }
+        return all;
+    }
+
+    @Test
+    void everyRowsetEitherHasAGuidOrSaysWhyNot() {
+        List<String> silent = new ArrayList<>();
+        for (Map.Entry<String, EClass> rowset : rowsets().entrySet()) {
+            boolean has = RowsetCatalog.guidOf(rowset.getValue()).filter(guid -> !guid.isEmpty()).isPresent();
+            if (!has && detail(rowset.getValue(), "noGuidBecause").isEmpty()) {
+                silent.add(rowset.getKey());
+            }
+        }
+
+        assertThat(silent).as("a rowset without a GUID is unreachable by GetSchemaDataSet(Guid); "
+                + "that may be unavoidable, but it must be written down as noGuidBecause, not left silent")
+                .isEmpty();
+    }
+
+    @Test
+    void everyGuidIsAWellFormedGuid() {
+        for (Map.Entry<String, EClass> rowset : rowsets().entrySet()) {
+            RowsetCatalog.guidOf(rowset.getValue()).ifPresent(guid -> {
+                assertThat(guid).as("%s", rowset.getKey()).matches(SHAPE);
+                // Not the same test: the shape admits values UUID.fromString rejects, and
+                // the client parses with the equivalent of the latter.
+                UUID.fromString(guid);
+            });
+        }
+    }
+
+    @Test
+    void noTwoRowsetsShareAGuidExceptTheOnePairThatMust() {
+        Map<String, List<String>> byGuid = new LinkedHashMap<>();
+        for (Map.Entry<String, EClass> rowset : rowsets().entrySet()) {
+            RowsetCatalog.guidOf(rowset.getValue()).ifPresent(
+                    guid -> byGuid.computeIfAbsent(guid.toUpperCase(java.util.Locale.ROOT), any -> new ArrayList<>())
+                            .add(rowset.getKey()));
+        }
+
+        List<List<String>> shared = byGuid.values().stream().filter(names -> names.size() > 1)
+                .filter(names -> !SHARE_ONE_GUID.containsAll(names)).toList();
+
+        assertThat(shared).as("two rowsets on one GUID means a client resolving by GUID can only ever "
+                + "reach whichever its lookup table wrote last").isEmpty();
+    }
+
+    /**
+     * Where a GUID came from, for every GUID no specification states.
+     * <p>
+     * [MS-SSAS] publishes no rowset GUIDs at all — a {@code source=MS-SSAS-*} on a
+     * rowset says where its <em>columns</em> come from. So any GUID we carry was
+     * either read off a real server, taken from a decompiled client, or taken from
+     * OLE DB; and which of the three it was is the only thing that lets a later
+     * reader weigh it.
+     */
+    @Test
+    void aGuidNoSpecificationStatesSaysWhereItCameFrom() {
+        List<String> unattributed = new ArrayList<>();
+        for (Map.Entry<String, EClass> rowset : rowsets().entrySet()) {
+            if (RowsetCatalog.guidOf(rowset.getValue()).isEmpty()) {
+                continue;
+            }
+            String source = RowsetCatalog.sourceOf(rowset.getValue()).orElse("");
+            boolean fromOleDb = source.startsWith("OLEDB") || source.equals("PROPRIETARY") || source.equals("INFERRED");
+            if (!fromOleDb && detail(rowset.getValue(), "guidSource").isEmpty()) {
+                unattributed.add(rowset.getKey());
+            }
+        }
+
+        assertThat(unattributed).as("these carry a GUID that no specification states and no note attributes, "
+                + "so nobody can tell whether it is right").isEmpty();
+    }
+}

--- a/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/LexicalTest.java
+++ b/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/LexicalTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.model.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A timestamp is written the one way {@code xsd:dateTime} allows, whichever of
+ * the three paths it takes to the wire.
+ * <p>
+ * The lexical form requires {@code hh:mm:ss}. A client handed anything else does
+ * not complain: it stores the parse failure as the cell's value, and the error
+ * surfaces much later as a cast that cannot succeed.
+ */
+class LexicalTest {
+
+    /**
+     * {@code LocalDateTime.toString()} drops seconds that are zero, and columns
+     * such as MDSCHEMA_CUBES.LAST_DATA_UPDATE hold the start of a day.
+     */
+    @Test
+    void midnightKeepsItsSeconds() {
+        LocalDateTime midnight = LocalDateTime.of(2026, 8, 15, 0, 0);
+
+        assertThat(midnight).hasToString("2026-08-15T00:00");
+        assertThat(Lexical.of(midnight)).isEqualTo("2026-08-15T00:00:00");
+    }
+
+    /** The fraction is kept when there is one - it is optional, not truncated. */
+    @Test
+    void subSecondPrecisionSurvives() {
+        assertThat(Lexical.of(LocalDateTime.of(2026, 8, 15, 12, 24, 33, 956_667_000)))
+                .isEqualTo("2026-08-15T12:24:33.956667");
+    }
+
+    /** A JDBC driver hands back a Timestamp, whose toString uses a space. */
+    @Test
+    void aSqlTimestampIsNotWrittenWithASpace() {
+        java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf(LocalDateTime.of(2026, 8, 15, 0, 0));
+
+        assertThat(timestamp.toString()).contains(" ");
+        assertThat(Lexical.of((Object) timestamp)).isEqualTo("2026-08-15T00:00:00");
+    }
+
+    /** XMLA carries no offset, so one is normalised to UTC rather than dropped. */
+    @Test
+    void anOffsetIsNormalisedToUtc() {
+        java.time.OffsetDateTime berlin = LocalDateTime.of(2026, 8, 15, 14, 35, 29).atOffset(ZoneOffset.ofHours(2));
+
+        assertThat(Lexical.of((Object) berlin)).isEqualTo("2026-08-15T12:35:29");
+    }
+
+    @Test
+    void nullStaysNull() {
+        assertThat(Lexical.of((Object) null)).isNull();
+    }
+
+    /** Anything that is not a point in time is left to the value itself. */
+    @Test
+    void otherValuesAreUnchanged() {
+        assertThat(Lexical.of((Object) 1100)).isEqualTo("1100");
+        assertThat(Lexical.of((Object) "FoodMart")).isEqualTo("FoodMart");
+    }
+}

--- a/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/RequestTypeEnumAgreesTest.java
+++ b/model/io/src/test/java/org/eclipse/daanse/xmla/model/io/RequestTypeEnumAgreesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.model.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.daanse.xmla.model.xmla.RequestTypeEnum;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Two lists that have to agree, and did not.
+ * <p>
+ * A rowset needs an entry in two places to be usable: an EClass in a rowset
+ * model, which decides the columns and the inline schema, and a literal in
+ * {@link RequestTypeEnum}, which is how the request is parsed off the wire.
+ * Neither implies the other, and only this test forces them together.
+ * <p>
+ * A rowset with a model class, a GUID, restrictions, a provider and a row in
+ * {@code DISCOVER_SCHEMA_ROWSETS} but no enum literal is announced to every
+ * client and refused to every client that takes the offer up — a promise made
+ * and broken, where saying nothing would have cost nothing.
+ */
+class RequestTypeEnumAgreesTest {
+
+    @Test
+    void everyRowsetInTheCatalogueCanBeAskedFor() {
+        Set<String> onTheWire = RequestTypeEnum.VALUES.stream().map(RequestTypeEnum::getLiteral)
+                .collect(Collectors.toSet());
+
+        Set<String> unaskable = RowsetCatalog.requestTypes().stream().filter(name -> !onTheWire.contains(name))
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+
+        assertThat(unaskable).as("these are modelled, announced in DISCOVER_SCHEMA_ROWSETS, and rejected "
+                + "when a client asks for them, because the request type never parses").isEmpty();
+    }
+
+    /**
+     * The other direction is allowed, and deliberately so.
+     * <p>
+     * The enum is the vocabulary of the protocol; the catalogue is what this build
+     * happens to model. A literal without a model class parses and is then refused
+     * as unsupported, which is the truthful answer — unlike the reverse.
+     */
+    @Test
+    void theEnumMayNameMoreThanIsModelled() {
+        Set<String> modelled = RowsetCatalog.requestTypes();
+
+        assertThat(RequestTypeEnum.VALUES).as("sanity: the enum is populated at all").isNotEmpty();
+        assertThat(RequestTypeEnum.VALUES.stream().map(RequestTypeEnum::getLiteral))
+                .as("and it covers what is modelled").containsAll(modelled);
+    }
+}

--- a/model/rowset.core/model/rowset-core.ecore
+++ b/model/rowset.core/model/rowset-core.ecore
@@ -60,6 +60,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_DATASOURCES"/>
       <details key="guid" value="06C03D41-F66D-49F3-B1B8-987F7AF4CF18"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="dataSourceName" lowerBound="1"
@@ -148,6 +150,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_ENUMERATORS"/>
       <details key="guid" value="55A9E78B-ACCB-45B4-95A6-94C5065617A7"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enumName" lowerBound="1"
@@ -225,6 +229,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_KEYWORDS"/>
       <details key="guid" value="1426C443-4CDD-4A40-8F45-572FAB9BBAA1"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="keyword" lowerBound="1"
@@ -250,6 +256,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_LITERALS"/>
       <details key="guid" value="C3EF5ECB-0A07-4665-A140-B075722DBDC2"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="literalName" lowerBound="1"
@@ -327,6 +335,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_PROPERTIES"/>
       <details key="guid" value="4B40ADFB-8B09-4758-97BB-636E8AE97BCF"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="propertyName" lowerBound="1"
@@ -403,6 +413,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_SCHEMA_ROWSETS"/>
       <details key="guid" value="EEA0302B-7922-4992-8991-0E605D0E5593"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="schemaName" lowerBound="1"

--- a/model/rowset.mining/model/rowset-mining.ecore
+++ b/model/rowset.mining/model/rowset-mining.ecore
@@ -33,6 +33,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_COLUMNS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A78-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="modelCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -460,6 +463,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_FUNCTIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A79-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="serviceName" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -548,6 +554,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_MODELS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A77-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="modelCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -757,6 +766,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_MODEL_CONTENT"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A76-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="modelCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -977,6 +989,10 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_MODEL_CONTENT_PMML"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="4290B2D5-0E9C-4AA7-9369-98C95CFD9D13"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
+      <details key="guidSharedWith" value="DMSCHEMA_MINING_MODEL_XML - see the note there."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="modelCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -1062,6 +1078,10 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_MODEL_XML"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="4290B2D5-0E9C-4AA7-9369-98C95CFD9D13"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
+      <details key="guidSharedWith" value="DMSCHEMA_MINING_MODEL_CONTENT_PMML. This is not a mistake and not ours: a real server advertises the one GUID on both rows, and ADOMD.NET declares it twice under two field names. A client that resolves a rowset by GUID can therefore only ever reach one of the two, whichever its lookup table wrote last; by name both are reachable. Dropping the GUID from one of them would not fix that and would make that one unreachable by GUID as well."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="modelCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -1147,6 +1167,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_SERVICES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A95-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="serviceName" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1441,6 +1464,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_SERVICE_PARAMETERS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="3ADD8A75-D8B9-11D2-8D2A-00E029154FDE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="serviceName" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1559,6 +1585,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_STRUCTURES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="883269F3-0CAD-462F-B6F5-E88A72418C4B"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="structureCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1724,6 +1753,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DMSCHEMA_MINING_STRUCTURE_COLUMNS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="9952E836-BFBF-4D1F-8535-9B67DBD9DDFE"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="structureCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/model/rowset.multidimensional/model/rowset-multidimensional.ecore
+++ b/model/rowset.multidimensional/model/rowset-multidimensional.ecore
@@ -33,6 +33,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_ACTIONS"/>
       <details key="guid" value="A07CCD08-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -158,6 +160,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_CUBES"/>
       <details key="guid" value="C8B522D8-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -355,6 +359,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_DIMENSIONS"/>
       <details key="guid" value="C8B522D9-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -531,6 +537,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_FUNCTIONS"/>
       <details key="guid" value="A07CCD07-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="functionName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -697,6 +705,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_HIERARCHIES"/>
       <details key="guid" value="C8B522DA-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -971,8 +981,11 @@
     </eAnnotations>
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_INPUT_DATASOURCES"/>
-      <details key="guid" value="d54b1b45-b226-4988-be89-13cb95f777ff"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD32-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
+      <details key="correctedFromSpec" value="This carried d54b1b45-b226-4988-be89-13cb95f777ff until the 2026-08 audit. That value occurs in no source: not in [MS-SSAS] (which publishes no rowset GUIDs at all), not in any recorded server answer, and not in either decompiled ADOMD version. A real server and both clients say A07CCD32, which also puts the rowset back in the a07ccd block where its neighbours are."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -1080,6 +1093,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_KPIS"/>
       <details key="guid" value="2AE44109-ED3D-4842-B16F-B694D1CB0E3F"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1275,6 +1290,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_LEVELS"/>
       <details key="guid" value="C8B522DB-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1530,6 +1547,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_MEASUREGROUPS"/>
       <details key="guid" value="E1625EBF-FA96-42FD-BEA6-DB90ADAFD96B"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1605,6 +1624,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_MEASUREGROUP_DIMENSIONS"/>
       <details key="guid" value="a07ccd33-8148-11d0-87bb-00c04fc33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1723,6 +1744,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_MEASURES"/>
       <details key="guid" value="C8B522DC-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1940,6 +1963,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_MEMBERS"/>
       <details key="guid" value="C8B522DE-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -2165,8 +2190,10 @@
     </eAnnotations>
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_PROPERTIES"/>
-      <details key="guid" value="C8B522DD-5CF3-11CE-ADE5-00AA0044773D"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="C8B522DD-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12, where the field is called MemberProperties rather than Properties - the field name is not the request type, and this rowset is the one place the two differ"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2404,6 +2431,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="MDSCHEMA_SETS"/>
       <details key="guid" value="A07CCD0B-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -2568,7 +2597,7 @@
         <details key="namespace" value="urn:schemas-microsoft-com:xml-analysis:rowset"/>
       </eAnnotations>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="skippable" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="skippable" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//BooleanObject">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="element"/>
         <details key="name" value="SKIPPABLE"/>

--- a/model/rowset.relational/model/rowset-relational.ecore
+++ b/model/rowset.relational/model/rowset-relational.ecore
@@ -87,6 +87,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DBSCHEMA_CATALOGS"/>
       <details key="guid" value="C8B52211-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -497,6 +499,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DBSCHEMA_COLUMNS"/>
       <details key="guid" value="C8B52214-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="tableCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1871,6 +1875,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DBSCHEMA_PROVIDER_TYPES"/>
       <details key="guid" value="C8B5222C-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="typeName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -2381,6 +2387,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DBSCHEMA_TABLES"/>
       <details key="guid" value="C8B52229-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="tableCatalog" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -4791,6 +4799,94 @@
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="element"/>
         <details key="name" value="VIEW_NAME"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DbschemaTrusteeRow">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="The trustees defined on the data store. Beyond OLE DB Appendix B: TRUSTEE is a later addition and is not listed there, so the four columns below are the ones System.Data.OleDb documents as its restriction columns. No source reachable from here states a wider result-column list, and none is invented; a provider that knows of more adds them."/>
+    </eAnnotations>
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value="dbschema-trustee-row"/>
+      <details key="kind" value="elementOnly"/>
+    </eAnnotations>
+    <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
+      <details key="requestType" value="DBSCHEMA_TRUSTEE"/>
+      <details key="guid" value="C8B522EF-5CF3-11CE-ADE5-00AA0044773D"/>
+      <details key="source" value="OLEDB-BEYOND-APPENDIX-B"/>
+      <details key="specUrl" value="https://learn.microsoft.com/en-us/dotnet/api/system.data.oledb.oledbschemaguid.trustee"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_NAME"/>
+        <details key="namespace" value="urn:schemas-microsoft-com:xml-analysis:rowset"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeGuid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_GUID"/>
+        <details key="namespace" value="urn:schemas-microsoft-com:xml-analysis:rowset"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteePropid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//UnsignedIntObject">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_PROPID"/>
+        <details key="namespace" value="urn:schemas-microsoft-com:xml-analysis:rowset"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeType" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//UnsignedIntObject">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_TYPE"/>
+        <details key="namespace" value="urn:schemas-microsoft-com:xml-analysis:rowset"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DbschemaTrusteeRestrictions">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="What a DBSCHEMA_TRUSTEE request may be restricted by. The feature order is the order the RestrictionsMask bitmask is defined over; the restriction name on the wire is the ExtendedMetaData name; the type is the feature type."/>
+    </eAnnotations>
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value="DbschemaTrusteeRestrictions"/>
+      <details key="kind" value="elementOnly"/>
+    </eAnnotations>
+    <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
+      <details key="requestType" value="DBSCHEMA_TRUSTEE"/>
+      <details key="role" value="restrictions"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"
+         unsettable="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_NAME"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeGuid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"
+         unsettable="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_GUID"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteePropid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//UnsignedIntObject"
+         unsettable="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_PROPID"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="trusteeType" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//UnsignedIntObject"
+         unsettable="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="TRUSTEE_TYPE"/>
         <details key="namespace" value="##targetNamespace"/>
       </eAnnotations>
     </eStructuralFeatures>

--- a/model/rowset.server/model/rowset-server.ecore
+++ b/model/rowset.server/model/rowset-server.ecore
@@ -33,6 +33,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_CALC_DEPENDENCY"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD46-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -136,6 +139,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_COMMANDS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD34-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionSpid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -259,6 +265,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_COMMAND_OBJECTS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD35-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
       <details key="correctedFromSpec" value="MS-SSAS names four columns OBJECTS_READS, OBJECTS_READ_KB, OBJECTS_WRITES and OBJECTS_WRITE_KB. The model writes OBJECT_ for all four. The prefix OBJECTS_ occurs in this one rowset and nowhere else in the specification; the other ten columns here use OBJECT_, the identical counter block in DISCOVER_OBJECT_ACTIVITY is spelled OBJECT_READS, and a live server sends OBJECT_READS. A name is not cosmetic: taken literally the column cannot be read from any server. See SPEC-DEVIATIONS.md K.1."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionSpid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
@@ -401,6 +410,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_CONNECTIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD25-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="connectionId" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -573,6 +585,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_CSDL_METADATA"/>
       <details key="guid" value="87B86062-21C3-460F-B4F8-5BE98394F13B"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="metaData" lowerBound="1"
@@ -598,6 +612,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_DB_CONNECTIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD2A-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="connectionId" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -715,6 +732,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_DB_MEM_STATS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD8C-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="ADOMD-19.114.12"/>
+      <details key="observedFrom" value="ADOMD.NET 19.114.12, AdomdSchemaGuid field DBMemoryStats - no recorded server answer carries this rowset"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -872,6 +892,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_DIMENSION_STAT"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD90-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -925,6 +948,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_INSTANCES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="20518699-2474-4C15-9885-0E947EC7A7E3"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="instanceName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -968,6 +994,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_JOBS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD27-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="spid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1061,6 +1090,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_LOCATIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD92-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="locationBackupFilePathname"
         eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1162,6 +1194,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_LOCKS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD24-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="spid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//IntObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1255,6 +1290,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_MASTER_KEY"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD29-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1278,6 +1316,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_MEMORYGRANT"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD23-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="memoryid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//LongObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1361,6 +1402,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_MEMORYUSAGE"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD21-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="memoryid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//UnsignedLong">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1514,6 +1558,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_MEM_STATS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD8A-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="ADOMD-19.114.12"/>
+      <details key="observedFrom" value="ADOMD.NET 19.114.12, AdomdSchemaGuid field MemoryStats - no recorded server answer carries this rowset"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="catalogName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1637,6 +1684,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_MODEL_SECURITY"/>
       <details key="source" value="OBSERVED"/>
+      <details key="guid" value="A07CCD88-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="ADOMD-19.114.12"/>
+      <details key="observedFrom" value="ADOMD.NET 19.114.12, AdomdSchemaGuid field ModelSecurity - no recorded server answer carries this rowset"/>
       <details key="observedFrom" value="ssas/telerik/DISCOVER_MODEL_SECURITY.xml"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseID" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
@@ -1672,6 +1722,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_OBJECT_ACTIVITY"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD36-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="objectParentPath" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1836,6 +1889,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_OBJECT_COUNTERS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD89-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="ADOMD-19.114.12"/>
+      <details key="observedFrom" value="ADOMD.NET 19.114.12, AdomdSchemaGuid field ObjectCounters - no recorded server answer carries this rowset"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="objectName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -1889,6 +1945,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_OBJECT_MEMORY_USAGE"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD37-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="objectParentPath" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -2016,6 +2075,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_PARTITION_DIMENSION_STAT"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD8E-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2107,6 +2169,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_PARTITION_STAT"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD8F-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2168,6 +2233,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_PERFORMANCE_COUNTERS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD2E-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="perfCounterName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -2201,6 +2269,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_RESOURCE_POOLS"/>
       <details key="guid" value="A07CCD47-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="OBSERVED"/>
       <details key="observedFrom" value="ssas/flexmonster/DISCOVER_RESOURCE_POOLS.xml"/>
     </eAnnotations>
@@ -2325,6 +2395,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_RING_BUFFERS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD48-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -2368,6 +2441,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_SESSIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD26-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services 13.0, DISCOVER_SCHEMA_ROWSETS answer to Excel (MSOLAP 16.0)"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionId" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -2656,6 +2732,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_STORAGE_TABLES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD43-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2757,6 +2836,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_STORAGE_TABLE_COLUMNS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD44-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -2953,6 +3035,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_STORAGE_TABLE_COLUMN_SEGMENTS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD45-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="databaseName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -3147,6 +3232,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_TRACES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1A-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="traceid" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3240,6 +3328,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_TRACE_COLUMNS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD18-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="data" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3263,6 +3354,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_TRACE_DEFINITION_PROVIDERINFO"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1B-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="data" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3286,6 +3380,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_TRACE_EVENT_CATEGORIES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD19-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="data" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3309,6 +3406,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_TRANSACTIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD28-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transactionId" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3373,6 +3473,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_OBJECTS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1D-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3476,6 +3579,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_OBJECT_COLUMNS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1E-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3599,6 +3705,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_PACKAGES"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1C-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3662,6 +3771,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_SESSIONS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD20-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3836,6 +3948,9 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_SESSION_TARGETS"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="guid" value="A07CCD1F-8148-11D0-87BB-00C04FC33942"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sessionName" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3909,6 +4024,7 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XEVENT_TRACE_DEFINITION"/>
       <details key="source" value="MS-SSAS-251031"/>
+      <details key="noGuidBecause" value="No source states one. [MS-SSAS] publishes no rowset GUIDs at all; the recorded server answer that supplies the other thirty-one DISCOVER_* values does not list this rowset; and ADOMD.NET 19.114.12 has a field for each of its five XEvent siblings but none for this one. A guessed GUID would be worse than none: a client resolving by GUID would reach the wrong rowset rather than fail."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="data" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -3932,6 +4048,8 @@
     <eAnnotations source="https://www.daanse.org/spec/xmla/rowset/1.0">
       <details key="requestType" value="DISCOVER_XML_METADATA"/>
       <details key="guid" value="3444B255-171E-4CB9-AD98-19E57888A75F"/>
+      <details key="guidSource" value="OBSERVED"/>
+      <details key="observedFrom" value="Analysis Services, DISCOVER_SCHEMA_ROWSETS answer (recorded-ssas.xml); the same value in ADOMD.NET 19.114.12 AdomdSchemaGuid. [MS-SSAS] states no rowset GUIDs at all, so the source detail above covers the columns, not this."/>
       <details key="source" value="MS-SSAS-251031"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="metaData" eType="ecore:EDataType urn:schemas-microsoft-com:xml-analysis:rowset:core#//XmlDocument">

--- a/model/xml.sql/model/xml-sql.ecore
+++ b/model/xml.sql/model/xml-sql.ecore
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="sql"
+    nsURI="urn:schemas-microsoft-com:xml-sql" nsPrefix="sql">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+    <details key="documentation" value="The annotation namespace an inline rowset schema puts on its column declarations.&#xA;&#xA;It is a small piece of SQLXML, the annotated-schema vocabulary that maps XML to relational columns, and XMLA borrows exactly one thing from it. Counted over the two specifications: [MS-SSAS-T] v18 writes sql:field 1361 times and [MS-SSAS] v37 writes it 886 times, and neither writes any other attribute of this namespace at all - no sql:relation, no sql:key-fields, no sql:datatype. So this package holds one attribute, and that is not an omission.&#xA;&#xA;Two facts about how it is used, both counted rather than assumed. It sits only on an XSD element declaration - xsd:element or xs:element, never on anything else. And in all 1419 declarations where both appear, sql:field is identical to name: the freedom SQLXML gives to call the column something other than the element is never taken here. A reader must therefore not treat a differing sql:field as impossible, only as unattested.&#xA;&#xA;model/io writes the attribute when it builds the schema that describes a rowset, and takes its namespace, prefix and name from this package rather than from constants of its own - which is the whole reason this package exists rather than two string literals."/>
+    <details key="oSGiCompatible" value="true"/>
+    <details key="basePackage" value="org.eclipse.daanse.xmla.model.xml"/>
+    <details key="prefix" value="XmlSql"/>
+    <details key="fileExtensions" value="xmlasql"/>
+    <details key="resource" value="XML"/>
+    <details key="literalsInterface" value="true"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="ColumnAnnotation">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="What this namespace contributes to one column declaration of an inline schema.&#xA;&#xA;Not a wire element of its own: nothing is ever serialized as a ColumnAnnotation. It exists so that the one attribute has somewhere to be declared, and so that a writer can ask the model what the attribute is called and in which namespace instead of repeating it."/>
+    </eAnnotations>
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value="ColumnAnnotation"/>
+      <details key="kind" value="empty"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="field" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="The name of the column the element stands for. In SQLXML this is what lets an element be named differently from the column behind it; in every rowset schema either specification states, it repeats the element's own name."/>
+      </eAnnotations>
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="attribute"/>
+        <details key="name" value="field"/>
+        <details key="namespace" value="urn:schemas-microsoft-com:xml-sql"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+</ecore:EPackage>

--- a/model/xml.sql/pom.xml
+++ b/model/xml.sql/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.xmla.model</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.xmla.model.xml.sql</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.fennec.emf</groupId>
+      <artifactId>org.eclipse.fennec.emf.osgi.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.25.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- The .ecore travels in the jar: a package that references these datatypes by
+         nsURI can only be generated if the referenced model is on the classpath. -->
+    <resources>
+      <resource>
+        <directory>model</directory>
+        <includes>
+          <include>**/*.ecore</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.daanse</groupId>
+        <artifactId>org.eclipse.daanse.tooling.emf.codegen.maven</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <ecoreFile>model/xml-sql.ecore</ecoreFile>
+              <outputDirectory>target/generated-sources/emf</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>7.1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/emf</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/model/xmla/model/xmla.ecore
+++ b/model/xmla/model/xmla.ecore
@@ -414,6 +414,7 @@
     <eLiterals name="DBSCHEMA_TABLE_PRIVILEGES" value="96" literal="DBSCHEMA_TABLE_PRIVILEGES"/>
     <eLiterals name="DBSCHEMA_TABLE_STATISTICS" value="97" literal="DBSCHEMA_TABLE_STATISTICS"/>
     <eLiterals name="DBSCHEMA_TRANSLATIONS" value="98" literal="DBSCHEMA_TRANSLATIONS"/>
+    <eLiterals name="DBSCHEMA_TRUSTEE" value="105" literal="DBSCHEMA_TRUSTEE"/>
     <eLiterals name="DBSCHEMA_USAGE_PRIVILEGES" value="99" literal="DBSCHEMA_USAGE_PRIVILEGES"/>
     <eLiterals name="DBSCHEMA_VIEWS" value="100" literal="DBSCHEMA_VIEWS"/>
     <eLiterals name="DBSCHEMA_VIEW_COLUMN_USAGE" value="101" literal="DBSCHEMA_VIEW_COLUMN_USAGE"/>
@@ -1236,6 +1237,11 @@
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="dbpropMsmdCurrentActivityID"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="https://www.daanse.org/spec/xmla/property/1.0">
+        <details key="access" value="ReadWrite"/>
+        <details key="accessSource" value="OBSERVED"/>
+        <details key="observedFrom" value="Analysis Services 13.0, DISCOVER_PROPERTIES answer to Excel (MSOLAP 16.0)"/>
+      </eAnnotations>
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="element"/>
         <details key="name" value="DbpropMsmdCurrentActivityID"/>

--- a/server/adapter.emf/src/main/java/org/eclipse/daanse/xmla/server/adapter/emf/EmfXmlaAdapter.java
+++ b/server/adapter.emf/src/main/java/org/eclipse/daanse/xmla/server/adapter/emf/EmfXmlaAdapter.java
@@ -57,6 +57,7 @@ import org.eclipse.daanse.xmla.api.auth.AuthenticatedIdentity;
 import org.eclipse.daanse.xmla.api.auth.InbandAuthenticator;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,25 +65,16 @@ import org.slf4j.LoggerFactory;
  * Serves an XMLA request from a byte stream, with the model doing the
  * describing.
  * <p>
- * Nothing is buffered on either side. The request is read up to the first body
- * element and then streamed; the response is written straight to the output as
- * the rows are produced. The model is the only description involved — the
- * request reaches the {@link XmlaConnector} as a {@link Discover} or an
- * {@link Execute}, the connector answers with EObjects, and those are what go
- * on the wire.
+ * Nothing is buffered on either side: the request is streamed from the first
+ * body element, the response written as the rows are produced. The request
+ * reaches the {@link XmlaConnector} as a {@link Discover} or an {@link Execute}
+ * and the EObjects it answers with go on the wire.
  * <p>
- * Three properties worth naming:
- * <ul>
- * <li>a request type it has no model for is not guessed: {@link RowsetCatalog}
- * decides, and an unknown type becomes the fault a Microsoft server returns for
- * the same request;</li>
- * <li>{@link AuthenticationRequiredException} is <em>not</em> a SOAP fault. It
- * flies before the first byte by construction and propagates to the transport,
- * which turns it into the {@code 401} challenge;</li>
- * <li>no failure is swallowed. Anything else thrown before the first byte
- * becomes a SOAP fault; after the first byte the response is partly on the
- * wire, so it is logged and the stream abandoned.</li>
- * </ul>
+ * A request type with no model is not guessed - {@link RowsetCatalog} decides.
+ * {@link AuthenticationRequiredException} is not a SOAP fault: it propagates to
+ * the transport, which turns it into the {@code 401} challenge. Anything else
+ * thrown before the first byte becomes a fault; after it, the response is partly
+ * written, so the failure is logged and the stream abandoned.
  */
 public class EmfXmlaAdapter {
 
@@ -98,21 +90,16 @@ public class EmfXmlaAdapter {
 
     /**
      * {@code XMLAnalysisError.0xC10E0002}: the authentication method is not
-     * supported.
-     * <p>
-     * The code the specification gives for an Authenticate this server cannot
-     * perform: no {@link InbandAuthenticator} is registered, or the handshake
+     * supported - no {@link InbandAuthenticator} is registered, or the handshake
      * failed.
      */
     private static final Long ERROR_AUTHENTICATION_UNSUPPORTED = 3238920194L;
     private static final String ERROR_SOURCE = "Daanse XMLA";
 
     /**
-     * Everything this server can negotiate through {@code ProtocolCapabilities}.
-     * <p>
-     * Empty: binary XML and compression are the capabilities the header exists for,
-     * and neither is implemented. Echoing one would have the client switch to an
-     * encoding this server cannot read.
+     * What {@code ProtocolCapabilities} may negotiate: nothing. Binary XML and
+     * compression are what the header exists for, and echoing one would have the
+     * client switch to an encoding this server cannot read.
      */
     private static final List<String> SUPPORTED_CAPABILITIES = List.of();
 
@@ -186,6 +173,12 @@ public class EmfXmlaAdapter {
 
         private final XmlaRequest incoming;
         private String minted;
+        /**
+         * The session an {@code EndSession} header asks to close, held until the
+         * request is allowed to be served. Ending it while reading the headers would
+         * mean a request that is about to be refused had already had its effect.
+         */
+        private String ending;
 
         private Exchange(XmlaRequest incoming) {
             this.incoming = incoming;
@@ -233,10 +226,14 @@ public class EmfXmlaAdapter {
         }
 
         if ("Discover".equals(body.getLocalPart())) {
-            return discover(envelope, target, request);
+            boolean started = discover(envelope, target, request);
+            endPending(exchange, request);
+            return started;
         }
         if ("Execute".equals(body.getLocalPart())) {
-            return execute(envelope, target, request);
+            boolean started = execute(envelope, target, request);
+            endPending(exchange, request);
+            return started;
         }
         writeFault(target, SoapFaultWriter.Kind.CLIENT,
                 "the body element " + body.getLocalPart() + " is neither Discover nor Execute", null);
@@ -313,17 +310,47 @@ public class EmfXmlaAdapter {
             rows = List.of();
         }
         if (rows.isEmpty() && "DISCOVER_SCHEMA_ROWSETS".equals(requestType)) {
-            // The one rowset a server can answer about itself: request types, restrictions
-            // in
-            // order, and the mask over their ordinals are all in the model. A connector
-            // that
-            // answers this rowset itself is left alone.
-            rows = RowsetCatalog.schemaRowsets();
+            // The one rowset a server answers about itself, and the model holds all of
+            // it: request types, restrictions in order, the mask over their ordinals. A
+            // connector that answers it itself is left alone; one that says what it
+            // serves gets that announced, and the whole model is the fallback rather
+            // than the goal - a rowset announced and then refused is a promise broken
+            // on the next request.
+            java.util.Set<String> served = connector.served();
+            rows = served.isEmpty() ? RowsetCatalog.schemaRowsets() : RowsetCatalog.schemaRowsets(served);
+        }
+        if ("DISCOVER_DATASOURCES".equals(requestType)) {
+            statePolicyInAuthenticationMode(rows);
         }
 
         XmlaMessageCodec.writeDiscoverResponse(target, responseHeaders(request, envelope.headers()), rowEClass.get(),
                 rows.iterator());
         return true;
+    }
+
+    /** The value of AuthenticationMode when the transport demands a login. */
+    private static final String AUTHENTICATED = "Authenticated";
+
+    /**
+     * Makes DISCOVER_DATASOURCES say what this endpoint demands.
+     * <p>
+     * [MS-SSAS] on the column: {@code Unauthenticated} means "no user ID or
+     * password has to be sent", {@code Authenticated} that they "MUST be included".
+     * A connector is handed a caller, not a policy, so it states the open case and
+     * this layer corrects it. Since both this rowset and DISCOVER_PROPERTIES are
+     * answered anonymously - a client has to ask before it knows whom to introduce
+     * itself as - the column is the only thing announcing that a challenge comes.
+     */
+    private void statePolicyInAuthenticationMode(List<EObject> rows) {
+        if (!policy.requirePrincipal()) {
+            return;
+        }
+        for (EObject row : rows) {
+            EStructuralFeature mode = row.eClass().getEStructuralFeature("authenticationMode");
+            if (mode != null && !mode.isMany()) {
+                row.eSet(mode, AUTHENTICATED);
+            }
+        }
     }
 
     /** @return whether the response has begun */
@@ -364,17 +391,14 @@ public class EmfXmlaAdapter {
     /**
      * One round of the specification's security-token handshake.
      * <p>
-     * The client's token goes to the {@link InbandAuthenticator}; the answer is
-     * either another token ({@code AuthenticateResponse}, handshake continues), the
-     * final token with the peer established, or the error for an authentication
-     * this server cannot perform - which is also the answer when no authenticator
-     * is registered.
+     * The client's token goes to the {@link InbandAuthenticator}, which answers
+     * with another token, the final one with the peer established, or the error for
+     * an authentication this server cannot perform.
      * <p>
-     * The established identity is bound to the session, because over HTTP there is
-     * no connection to bind it to. A client that has not opened one gets a session
-     * here, minted before the first round so that a multi-round handshake has a
-     * stable key, and carried back in the {@code <Session>} header. Without a
-     * session handler there is nothing to bind to, and the handshake is refused
+     * The identity binds to the session, there being no connection to bind it to
+     * over HTTP. A client without one gets a session minted before the first round,
+     * so a multi-round handshake has a stable key, and carried back in the
+     * {@code <Session>} header. With no session handler the handshake is refused
      * rather than silently forgotten.
      */
     private boolean authenticate(SoapEnvelopeReader.Envelope envelope, OutputStream target, XmlaRequest incoming,
@@ -434,15 +458,12 @@ public class EmfXmlaAdapter {
     /**
      * Ties this request and its session together in whichever direction is missing.
      * <p>
-     * A caller who proved who they are owns the session they are using: the
-     * identity is bound to it, so a later caller who merely knows the id cannot
-     * step into it. That matters because a session is not just a name - a backend
+     * A caller who proved who they are owns the session: the identity binds to it,
+     * so a later caller who merely knows the id cannot step in - and a backend
      * keeps per-session state under it, opened with the roles of whoever opened it.
-     * <p>
-     * The other direction is what the in-band handshake needs. Over HTTP there is
-     * no connection to hold what it established, so the session holds it and it is
-     * put back here. A stand-in identity does not count as having proved anything,
-     * so a session carrying a real one still wins over it.
+     * The other direction serves the in-band handshake, which has no connection to
+     * hold what it established. A stand-in identity proves nothing, so a session
+     * carrying a real one wins over it.
      */
     private XmlaRequest restoreIdentity(XmlaRequest request) {
         if (sessions == null || request.sessionId() == null) {
@@ -467,20 +488,17 @@ public class EmfXmlaAdapter {
     // --- sessions ---
 
     /**
-     * Applies whichever session headers the client sent, as the specification
-     * describes.
-     * <p>
-     * [MS-SSAS] 3.1.3.1 gives one rule here and it is a MUST: a {@code Session} or
-     * {@code EndSession} id the handler does not honour is a SOAP fault. Handing
-     * such a request through as if it had no session would let a client keep
-     * working under an identity its session no longer carries.
-     * <p>
-     * {@code BeginSession} is weaker - "the server <em>is to</em> respond by
-     * constructing a new session" - so it yields to a valid {@code Session} in the
-     * same message rather than minting a second id the one response header could
-     * not carry. Without a handler the endpoint is stateless and every request
-     * stands alone.
+     * Closes the session an {@code EndSession} header asked for, now that the
+     * request has been served rather than refused. A request that never got past
+     * the access policy leaves by exception and does not reach this.
      */
+    private void endPending(Exchange exchange, XmlaRequest request) {
+        if (exchange.ending != null && sessions != null) {
+            sessions.endSession(exchange.ending, request);
+            exchange.ending = null;
+        }
+    }
+
     private XmlaRequest applySessionHeaders(List<EObject> headers, Exchange exchange) {
         XmlaRequest request = exchange.incoming;
         if (sessions == null) {
@@ -499,7 +517,11 @@ public class EmfXmlaAdapter {
                 if (!sessions.checkSession(sessionId, request)) {
                     throw org.eclipse.daanse.xmla.api.XmlaRefusedException.invalidSession(sessionId);
                 }
-                sessions.endSession(sessionId, request);
+                // Noted, not done: a caller who is then refused must still find the session
+                // there on the retry. A client that waits for a 401 before it sends
+                // credentials - which is every HTTP client - would otherwise end its own
+                // session with the attempt that was rejected.
+                exchange.ending = sessionId;
                 request = request.withSession(null);
             } else if (header instanceof BeginSessionHeader) {
                 beginRequested = true;
@@ -518,11 +540,10 @@ public class EmfXmlaAdapter {
      * The headers to answer with: the session id, and the capabilities actually
      * agreed.
      * <p>
-     * The spec is explicit that a successful negotiation is the server echoing back
-     * the same {@code ProtocolCapabilities} element. Echoing an empty one says
-     * "nothing was negotiated", which is true here and is what a client needs to
-     * hear before it decides whether to keep using plain XML - answering nothing at
-     * all leaves it guessing.
+     * A successful negotiation is the server echoing the same
+     * {@code ProtocolCapabilities} element back. An empty one says "nothing was
+     * negotiated", which is true here; answering nothing at all leaves the client
+     * guessing whether to keep to plain XML.
      */
     private List<EObject> responseHeaders(XmlaRequest request, List<EObject> requested) {
         List<EObject> headers = new ArrayList<>(2);

--- a/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/AuthenticationModeTest.java
+++ b/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/AuthenticationModeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.server.adapter.emf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.daanse.xmla.api.XmlaConnector;
+import org.eclipse.daanse.xmla.api.XmlaRequest;
+import org.eclipse.daanse.xmla.model.rowset.core.RowsetCoreFactory;
+import org.eclipse.daanse.xmla.model.rowset.core.DiscoverDatasourcesRow;
+import org.eclipse.daanse.xmla.model.xmla.Discover;
+import org.eclipse.daanse.xmla.model.xmla.Execute;
+import org.eclipse.emf.ecore.EObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * DISCOVER_DATASOURCES says what the endpoint actually demands.
+ * <p>
+ * [MS-SSAS] on the AuthenticationMode column: {@code Unauthenticated} means "no
+ * user ID or password has to be sent", {@code Authenticated} that they "MUST be
+ * included". The connector cannot know which holds - it is handed a caller, not
+ * a policy - so it states the open case and the transport corrects it.
+ * <p>
+ * This column is read <em>before</em> the first challenge: properties and data
+ * sources are answered anonymously on purpose, so a client can ask before it
+ * knows whom to introduce itself as. Announcing Unauthenticated on an endpoint
+ * that then refuses leaves a client with nothing to offer, and it retries the
+ * handshake instead of authenticating.
+ */
+class AuthenticationModeTest {
+
+    private static final String DATASOURCES = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body>\
+            <Discover xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <RequestType>DISCOVER_DATASOURCES</RequestType>\
+            <Restrictions><RestrictionList/></Restrictions>\
+            <Properties><PropertyList/></Properties></Discover></soap:Body></soap:Envelope>""";
+
+    /** A connector that states the open case, as one with no policy must. */
+    private static XmlaConnector connectorSayingUnauthenticated() {
+        return new XmlaConnector() {
+
+            @Override
+            public List<EObject> discover(Discover request, XmlaRequest context) {
+                DiscoverDatasourcesRow row = RowsetCoreFactory.eINSTANCE.createDiscoverDatasourcesRow();
+                row.setDataSourceName("Daanse");
+                row.setAuthenticationMode("Unauthenticated");
+                return List.of(row);
+            }
+
+            @Override
+            public EObject execute(Execute request, XmlaRequest context) {
+                return null;
+            }
+        };
+    }
+
+    private static String answerUnder(AccessPolicy policy) {
+        ByteArrayOutputStream answer = new ByteArrayOutputStream();
+        new EmfXmlaAdapter(connectorSayingUnauthenticated(), null, null, policy).handle(
+                new ByteArrayInputStream(DATASOURCES.getBytes(StandardCharsets.UTF_8)), answer,
+                XmlaRequest.anonymous());
+        return answer.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void anEndpointThatDemandsALoginSaysSo() {
+        String answer = answerUnder(new AccessPolicy(true, Set.of("DISCOVER_PROPERTIES", "DISCOVER_DATASOURCES")));
+
+        assertThat(answer).contains("<AuthenticationMode>Authenticated</AuthenticationMode>")
+                .doesNotContain("Unauthenticated");
+    }
+
+    @Test
+    void anOpenEndpointIsLeftAsTheConnectorStatedIt() {
+        String answer = answerUnder(AccessPolicy.OPEN);
+
+        assertThat(answer).contains("<AuthenticationMode>Unauthenticated</AuthenticationMode>");
+    }
+}

--- a/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/EmptyHeaderTest.java
+++ b/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/EmptyHeaderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.server.adapter.emf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.eclipse.daanse.xmla.api.XmlaConnector;
+import org.eclipse.daanse.xmla.api.XmlaRequest;
+import org.eclipse.daanse.xmla.model.xmla.Discover;
+import org.eclipse.daanse.xmla.model.xmla.Execute;
+import org.eclipse.emf.ecore.EObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An envelope with nothing to say carries no {@code Header} element.
+ * <p>
+ * This looks like tidiness and is not. {@code <soap:Header/>} is one
+ * self-closing node: a reader that pairs {@code ReadStartElement} with
+ * {@code ReadEndElement} consumes the entire element on the first call, then
+ * takes the <em>next</em> end element with the second. From there it is one
+ * element out of step for the whole document and eventually reads past the end,
+ * which surfaces as a parse failure at the last byte, nowhere near the cause. A
+ * recorded Analysis Services writes {@code <soap:Envelope><soap:Body>} with no
+ * header at all.
+ */
+class EmptyHeaderTest {
+
+    private static final String ENVELOPE = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\
+            <soap:Body>%s</soap:Body></soap:Envelope>""";
+
+    private static final String DISCOVER = """
+            <Discover xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <RequestType>DISCOVER_SCHEMA_ROWSETS</RequestType>\
+            <Restrictions><RestrictionList/></Restrictions>\
+            <Properties><PropertyList/></Properties></Discover>""";
+
+    /** A request that opens a session, which is what puts a header in the answer. */
+    private static final String BEGIN_SESSION = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\
+            <soap:Header><BeginSession xmlns="urn:schemas-microsoft-com:xml-analysis" \
+            soap:mustUnderstand="1"/></soap:Header>\
+            <soap:Body><Execute xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <Command><Statement/></Command><Properties><PropertyList/></Properties>\
+            </Execute></soap:Body></soap:Envelope>""";
+
+    /** A session handler, because only a session puts a header in an answer. */
+    private static final class Sessions extends org.eclipse.daanse.xmla.api.SimpleSessionHandler {
+    }
+
+    private static String send(String message) {
+        return send(message, null);
+    }
+
+    private static String send(String message, Sessions sessions) {
+        XmlaConnector connector = new XmlaConnector() {
+
+            @Override
+            public List<EObject> discover(Discover request, XmlaRequest context) {
+                return List.of();
+            }
+
+            @Override
+            public EObject execute(Execute request, XmlaRequest context) {
+                return null;
+            }
+        };
+        ByteArrayOutputStream answer = new ByteArrayOutputStream();
+        new EmfXmlaAdapter(connector, sessions, null).handle(
+                new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8)), answer, XmlaRequest.anonymous());
+        return answer.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void anAnswerWithNoHeadersHasNoHeaderElement() {
+        String answer = send(ENVELOPE.formatted(DISCOVER));
+
+        assertThat(answer).as("an empty Header puts a paired-read parser one element out of step")
+                .doesNotContain("Header");
+        assertThat(answer).as("the body still follows the envelope directly").contains("Envelope").contains("Body");
+    }
+
+    /**
+     * The other half: when there <em>is</em> something to say, it must still be
+     * said. Removing the element unconditionally would silence the session id.
+     */
+    @Test
+    void anAnswerWithAHeaderStillCarriesIt() {
+        String answer = send(BEGIN_SESSION, new Sessions());
+
+        assertThat(answer).as("BeginSession is answered with a Session header").contains("Header")
+                .contains("Session");
+    }
+}

--- a/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/FaultShapeTest.java
+++ b/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/FaultShapeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.server.adapter.emf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.eclipse.daanse.xmla.api.XmlaConnector;
+import org.eclipse.daanse.xmla.api.XmlaRequest;
+import org.eclipse.daanse.xmla.model.xmla.Discover;
+import org.eclipse.daanse.xmla.model.xmla.Execute;
+import org.eclipse.emf.ecore.EObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shape of a fault, and the one rule that makes it readable at the far end.
+ * <p>
+ * A client reads {@code Error/@ErrorCode} without asking whether it is there:
+ * ADOMD hands the attribute straight to {@code XmlConvert.ToUInt32}, which
+ * throws on {@code null} and is not caught. An {@code <Error>} without a code
+ * therefore replaces our message with the client's own parse failure. Since a
+ * fault needs either that element or a {@code faultstring}, and the
+ * {@code faultstring} is always written, the element is simply left out where
+ * no code is known — rather than carrying an invented one.
+ */
+class FaultShapeTest {
+
+    private static final String ENVELOPE = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\
+            <soap:Body>%s</soap:Body></soap:Envelope>""";
+
+    private static String discoverOf(String requestType) {
+        return """
+                <Discover xmlns="urn:schemas-microsoft-com:xml-analysis">\
+                <RequestType>%s</RequestType>\
+                <Restrictions><RestrictionList/></Restrictions>\
+                <Properties><PropertyList/></Properties></Discover>""".formatted(requestType);
+    }
+
+    private static final XmlaConnector STUB = new XmlaConnector() {
+
+        @Override
+        public List<EObject> discover(Discover request, XmlaRequest context) {
+            return List.of();
+        }
+
+        @Override
+        public EObject execute(Execute request, XmlaRequest context) {
+            return null;
+        }
+    };
+
+    private static String send(String body) {
+        ByteArrayOutputStream answer = new ByteArrayOutputStream();
+        new EmfXmlaAdapter(STUB, null, null).handle(
+                new ByteArrayInputStream(ENVELOPE.formatted(body).getBytes(StandardCharsets.UTF_8)), answer,
+                XmlaRequest.anonymous());
+        return answer.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void anUnknownRequestTypeFaultsWithItsCode() {
+        String answer = send(discoverOf("NO_SUCH_ROWSET"));
+
+        assertThat(answer).contains("Fault");
+        assertThat(answer).contains("Error");
+        // Present, and a decimal unsigned 32-bit number - the client parses it as one.
+        assertThat(answer).containsPattern("ErrorCode=\"\\d+\"");
+    }
+
+    @Test
+    void aFaultWithoutAKnownCodeCarriesNoErrorElement() {
+        String answer = send("<NotXmlaAtAll/>");
+
+        assertThat(answer).contains("Fault");
+        assertThat(answer).as("the message travels in faultstring").contains("faultstring");
+        // Neither the element nor an empty attribute: both would be read as a code.
+        assertThat(answer).doesNotContain("ErrorCode");
+        assertThat(answer).doesNotContain("<detail>");
+    }
+}

--- a/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/RootNamespaceTest.java
+++ b/server/adapter.emf/src/test/java/org/eclipse/daanse/xmla/server/adapter/emf/RootNamespaceTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.server.adapter.emf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.eclipse.daanse.xmla.api.XmlaConnector;
+import org.eclipse.daanse.xmla.api.XmlaRequest;
+import org.eclipse.daanse.xmla.model.xmla.Discover;
+import org.eclipse.daanse.xmla.model.xmla.Execute;
+import org.eclipse.daanse.xmla.model.xmla.RowsetCell;
+import org.eclipse.daanse.xmla.model.xmla.RowsetColumn;
+import org.eclipse.daanse.xmla.model.xmla.RowsetResult;
+import org.eclipse.daanse.xmla.model.xmla.RowsetRow;
+import org.eclipse.daanse.xmla.model.xmla.XmlaFactory;
+import org.eclipse.emf.ecore.EObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What each {@code <root>} must declare.
+ * <p>
+ * A response names types as QNames in two places a namespace-aware client
+ * resolves for real: {@code DISCOVER_SCHEMA_ROWSETS} writes
+ * {@code <Type>xsd:string</Type>} as element content, and a variant cell carries
+ * {@code xsi:type="xsd:int"}. Both are written after the inline schema has
+ * closed, so the schema's own {@code xsd} binding is out of scope by then. The
+ * prefix has to be bound on the root or it resolves to nothing.
+ */
+class RootNamespaceTest {
+
+    private static final String XSD = "xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"";
+    private static final String XSI = "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
+    private static final String EX = "urn:schemas-microsoft-com:xml-analysis:exception";
+
+    private static final String ENVELOPE = """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\
+            <soap:Body>%s</soap:Body></soap:Envelope>""";
+
+    private static final String DISCOVER = """
+            <Discover xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <RequestType>DISCOVER_SCHEMA_ROWSETS</RequestType>\
+            <Restrictions><RestrictionList/></Restrictions>\
+            <Properties><PropertyList/></Properties></Discover>""";
+
+    /** A rowset the stub connector has no rows for, and no fallback fills. */
+    private static final String DISCOVER_NOBODY_ANSWERS = """
+            <Discover xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <RequestType>DBSCHEMA_TRUSTEE</RequestType>\
+            <Restrictions><RestrictionList/></Restrictions>\
+            <Properties><PropertyList/></Properties></Discover>""";
+
+    private static final String EXECUTE = """
+            <Execute xmlns="urn:schemas-microsoft-com:xml-analysis">\
+            <Command><Statement>SELECT FROM [Sales]</Statement></Command>\
+            <Properties><PropertyList><Format>Tabular</Format></PropertyList></Properties></Execute>""";
+
+    /** A one-column, one-row tabular result — enough to reach the rowset root. */
+    private static RowsetResult tabularResult() {
+        XmlaFactory factory = XmlaFactory.eINSTANCE;
+        RowsetResult result = factory.createRowsetResult();
+        result.setSchemaIncluded(true);
+
+        RowsetColumn column = factory.createRowsetColumn();
+        column.setField("MEASURE");
+        column.setName("MEASURE");
+        column.setXsdType("xsd:int");
+        result.getColumns().add(column);
+
+        RowsetCell cell = factory.createRowsetCell();
+        cell.setName("MEASURE");
+        cell.setValue("42");
+        RowsetRow row = factory.createRowsetRow();
+        row.getCells().add(cell);
+        result.getRows().add(row);
+        return result;
+    }
+
+    private static String send(String body, EObject executeResult) {
+        XmlaConnector connector = new XmlaConnector() {
+
+            @Override
+            public List<EObject> discover(Discover request, XmlaRequest context) {
+                return List.of();
+            }
+
+            @Override
+            public EObject execute(Execute request, XmlaRequest context) {
+                return executeResult;
+            }
+        };
+        ByteArrayOutputStream answer = new ByteArrayOutputStream();
+        new EmfXmlaAdapter(connector, null, null).handle(
+                new ByteArrayInputStream(ENVELOPE.formatted(body).getBytes(StandardCharsets.UTF_8)), answer,
+                XmlaRequest.anonymous());
+        return answer.toString(StandardCharsets.UTF_8);
+    }
+
+    /** The element text between {@code <root} and the first {@code >}. */
+    private static String rootTag(String message) {
+        int start = message.indexOf("<root");
+        assertThat(start).as("the answer carries a root element:%n%s", message).isNotNegative();
+        return message.substring(start, message.indexOf('>', start));
+    }
+
+    @Test
+    void theDiscoverRootBindsXsd() {
+        String root = rootTag(send(DISCOVER, null));
+
+        assertThat(root).as("DISCOVER_SCHEMA_ROWSETS writes <Type>xsd:string</Type> as content").contains(XSD);
+        assertThat(root).contains(XSI);
+        assertThat(root).as("in-band messages are written into this root").contains(EX);
+    }
+
+    @Test
+    void theTabularExecuteRootBindsXsd() {
+        String root = rootTag(send(EXECUTE, tabularResult()));
+
+        assertThat(root).as("a variant cell names its own type as xsi:type=\"xsd:int\"").contains(XSD);
+        assertThat(root).contains(XSI);
+        assertThat(root).as("in-band messages are written into this root too").contains(EX);
+    }
+
+    @Test
+    void anEmptyExecuteRootStaysEmpty() {
+        String answer = send(EXECUTE, null);
+
+        // A client checks this root is genuinely empty and refuses anything else, so
+        // nothing beyond the namespace declarations belongs here.
+        assertThat(rootTag(answer)).contains("urn:schemas-microsoft-com:xml-analysis:empty");
+        assertThat(answer).doesNotContain("<row");
+    }
+
+    /**
+     * The other half of the rule above: {@code empty} belongs to Execute alone.
+     * <p>
+     * A Discover with nothing to say still answers with a rowset root and its inline
+     * schema. The difference is not cosmetic. AMO reads a batch of Discovers and
+     * names each answer's table from the {@code name} attribute of its root; an
+     * {@code empty} root carries no name, the count of names then disagrees with the
+     * count of tables, and it abandons naming for the whole batch rather than for
+     * the one answer. Zero rows and nothing to report are different things, and only
+     * one of them is true here.
+     */
+    @Test
+    void aDiscoverWithNoRowsIsStillARowset() {
+        String answer = send(DISCOVER_NOBODY_ANSWERS, null);
+
+        assertThat(rootTag(answer)).as("a rowset with no rows, not an empty result")
+                .contains("urn:schemas-microsoft-com:xml-analysis:rowset");
+        assertThat(answer).as("the columns are what the client reads even when there are no values")
+                .contains("complexType");
+        assertThat(answer).doesNotContain("xml-analysis:empty");
+    }
+
+    /**
+     * Announce what can be answered, not what can be modelled.
+     * <p>
+     * A connector that leaves {@code DISCOVER_SCHEMA_ROWSETS} to the transport can
+     * still say what it reaches. Where it does, the transport must not offer the
+     * rest: a client that asks for an announced rowset and gets a fault has been
+     * misled, and it had no way to know in advance.
+     */
+    @Test
+    void aConnectorThatSaysWhatItServesIsTakenAtItsWord() {
+        XmlaConnector narrow = new XmlaConnector() {
+
+            @Override
+            public List<EObject> discover(Discover request, XmlaRequest context) {
+                return List.of();
+            }
+
+            @Override
+            public EObject execute(Execute request, XmlaRequest context) {
+                return null;
+            }
+
+            @Override
+            public java.util.Set<String> served() {
+                return java.util.Set.of("DISCOVER_SCHEMA_ROWSETS", "MDSCHEMA_CUBES");
+            }
+        };
+
+        ByteArrayOutputStream answer = new ByteArrayOutputStream();
+        new EmfXmlaAdapter(narrow, null, null).handle(
+                new ByteArrayInputStream(ENVELOPE.formatted(DISCOVER).getBytes(StandardCharsets.UTF_8)), answer,
+                XmlaRequest.anonymous());
+        String message = answer.toString(StandardCharsets.UTF_8);
+
+        assertThat(message).contains("<SchemaName>DISCOVER_SCHEMA_ROWSETS</SchemaName>")
+                .contains("<SchemaName>MDSCHEMA_CUBES</SchemaName>");
+        assertThat(message).as("this one is in the model and not in the connector's reach")
+                .doesNotContain("<SchemaName>DBSCHEMA_TRUSTEE</SchemaName>");
+    }
+}

--- a/server/auth.dummy/src/main/java/org/eclipse/daanse/xmla/server/auth/dummy/BasicAuthPipeRoleAuthenticator.java
+++ b/server/auth.dummy/src/main/java/org/eclipse/daanse/xmla/server/auth/dummy/BasicAuthPipeRoleAuthenticator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.xmla.server.auth.dummy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.daanse.xmla.api.XmlaRequest;
+import org.eclipse.daanse.xmla.api.auth.AuthRanking;
+import org.eclipse.daanse.xmla.api.auth.AuthenticatedIdentity;
+import org.eclipse.daanse.xmla.api.auth.Claims;
+import org.eclipse.daanse.xmla.api.auth.NamedPrincipal;
+import org.eclipse.daanse.xmla.api.auth.XmlaAuthenticator;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The caller says who they are and which roles they hold, in the user name, and
+ * this believes them.
+ * <p>
+ * {@code UserName|Role1|Role2} in HTTP Basic, password ignored - the same
+ * convention the servlet filter of the same purpose already uses, so both
+ * endpoints of a deployment behave alike. Logging in as
+ * {@code someone|California manager} is how you see a catalog the way that role
+ * sees it, which is otherwise only reachable by running a real directory.
+ * <p>
+ * It verifies nothing. Unlike {@link FixedIdentityAuthenticator} it does answer
+ * {@link Result.Authenticated}, because a caller who sent credentials has made a
+ * claim about themselves and a rule that demands authentication should see it
+ * satisfied - which is exactly what makes this dangerous outside a development
+ * server, and why it too refuses to come up without being told so.
+ */
+@Component(service = XmlaAuthenticator.class, configurationPolicy = ConfigurationPolicy.REQUIRE, property = "service.ranking:Integer="
+        + AuthRanking.BASIC)
+@Designate(ocd = BasicAuthPipeRoleAuthenticator.Config.class)
+public class BasicAuthPipeRoleAuthenticator implements XmlaAuthenticator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthPipeRoleAuthenticator.class);
+
+    private static final String PREFIX = "Basic ";
+
+    private volatile String realm;
+
+    @ObjectClassDefinition
+    @interface Config {
+
+        /**
+         * Confirms that this endpoint accepts whatever the caller claims. Without it the
+         * component does not come up, so the decision cannot be made by accident.
+         */
+        boolean acknowledgeUnverifiedCredentials() default false;
+
+        /** What the challenge names, which is what a client shows in its login prompt. */
+        String realm() default "Daanse";
+    }
+
+    @Activate
+    void activate(Config config) {
+        if (!config.acknowledgeUnverifiedCredentials()) {
+            throw new IllegalStateException("this component grants the roles a caller asks for without verifying "
+                    + "anything; set acknowledgeUnverifiedCredentials to confirm that is intended");
+        }
+        realm = config.realm();
+        LOGGER.warn("callers are granted the roles they name in the user name ('UserName|Role1|Role2'): "
+                + "credentials are not verified");
+    }
+
+    @Override
+    public String scheme() {
+        return "Basic";
+    }
+
+    @Override
+    public String challenge() {
+        return PREFIX + "realm=\"" + realm + "\"";
+    }
+
+    @Override
+    public Result authenticate(XmlaRequest request) {
+        String header = authorization(request);
+        if (header == null || !header.regionMatches(true, 0, PREFIX, 0, PREFIX.length())) {
+            return new Result.NotMine();
+        }
+        String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(header.substring(PREFIX.length()).trim()),
+                    StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException notBase64) {
+            return new Result.Refused("the Basic credentials are not valid base64");
+        }
+        // The password is the part this deliberately does not look at.
+        int colon = decoded.indexOf(':');
+        String userPart = colon < 0 ? decoded : decoded.substring(0, colon);
+
+        String[] pieces = userPart.split("\\|");
+        Set<String> roles = new LinkedHashSet<>();
+        for (int i = 1; i < pieces.length; i++) {
+            if (!pieces[i].isBlank()) {
+                roles.add(pieces[i].trim());
+            }
+        }
+        String userName = pieces.length == 0 ? "" : pieces[0].trim();
+        LOGGER.debug("caller '{}' claims roles {}", userName, roles);
+        return new Result.Authenticated(new AuthenticatedIdentity(new NamedPrincipal(userName), roles, Claims.none()),
+                null);
+    }
+
+    /** Header names are case-insensitive, and containers disagree about the case. */
+    private static String authorization(XmlaRequest request) {
+        for (Map.Entry<String, List<String>> header : request.headers().entrySet()) {
+            if ("Authorization".equalsIgnoreCase(header.getKey()) && !header.getValue().isEmpty()) {
+                return header.getValue().getFirst();
+            }
+        }
+        return null;
+    }
+}

--- a/server/jdk.httpserver/src/main/java/org/eclipse/daanse/xmla/server/jdk/httpserver/EmfXmlaHttpHandler.java
+++ b/server/jdk.httpserver/src/main/java/org/eclipse/daanse/xmla/server/jdk/httpserver/EmfXmlaHttpHandler.java
@@ -36,18 +36,16 @@ import com.sun.net.httpserver.HttpHandler;
  * The XMLA endpoint: HTTP in, HTTP out, nothing in between held in memory.
  * <p>
  * The response streams: the adapter writes straight onto the socket, so a
- * result of any size costs one row at a time. A status code cannot be taken
- * back once the first byte is out, so the {@code 200} is sent lazily, on the
- * first write - everything decided before then, such as an authentication
- * challenge or a connector demanding a login, still chooses its own status
- * line.
+ * result of any size costs one row at a time. The {@code 200} is sent lazily on
+ * the first write, since a status cannot be taken back once a byte is out -
+ * anything decided before then still picks its own status line.
  * <p>
- * Authentication is an {@link AuthenticationChain} and permissive at this
- * layer: a request nobody claims runs anonymously, because XMLA clients probe
- * {@code DISCOVER_PROPERTIES} before they log in. The refusal, if any, comes
- * from the backend as {@link AuthenticationRequiredException} and is answered
- * {@code 401} with the challenge of every mechanism that has one, or
- * {@code 403} when none does.
+ * Authentication is an {@link AuthenticationChain} and permissive here: a
+ * request nobody claims runs anonymously, because clients probe
+ * {@code DISCOVER_PROPERTIES} before they log in. The refusal comes from the
+ * backend as {@link AuthenticationRequiredException} and is answered
+ * {@code 401} with the challenge of every mechanism that has one, {@code 403}
+ * when none does.
  */
 public class EmfXmlaHttpHandler implements HttpHandler {
 
@@ -154,6 +152,12 @@ public class EmfXmlaHttpHandler implements HttpHandler {
             }
         } catch (IOException | RuntimeException e) {
             LOGGER.error("failed while serving {}", exchange.getRequestURI(), e);
+            throw e;
+        } catch (Error e) {
+            // An Error is not this handler's to recover from, but dropping it here would
+            // close the connection with nothing written and nothing logged - the client
+            // sees a reset and the server looks healthy. It is logged and rethrown.
+            LOGGER.error("error while serving {}", exchange.getRequestURI(), e);
             throw e;
         } finally {
             exchange.close();


### PR DESCRIPTION
…ds to read an answer

Every rowset a client cannot reach by name it resolves through the SchemaGuid column, so a missing GUID makes a rowset unreachable. The ones that were absent are added, each with a guidSource saying where the value comes from, and the ones already present gained the same attribution. Three findings the model now records rather than hides: two mining rowsets genuinely share one GUID, MDSCHEMA_INPUT_DATASOURCES carried a value that occurs in no source, and one rowset has none and says why. With the missing DBSCHEMA_TRUSTEE literal.

One lexical form for timestamps on all three paths to the wire, since seconds that are zero make an invalid xsd:dateTime and a client discards the whole answer rather than the value. No Header element where there are no headers - an empty one puts a paired-read parser out of step for the rest of the document. DISCOVER_DATASOURCES states what the endpoint demands, since that column is read before the first challenge. The adapter announces only what the connector serves.
